### PR TITLE
Honor CFLAGS and LDFLAGS

### DIFF
--- a/Config.mk.in
+++ b/Config.mk.in
@@ -27,9 +27,9 @@ O		:= .o/
 
 ################ Compiler options ####################################
 
-CFLAGS		:= -Wall -Wextra -Wredundant-decls -Wshadow \
+CFLAGS		:= @CFLAGS@ -Wall -Wextra -Wredundant-decls -Wshadow \
 		   -std=c11 -I/usr/include/libxml2
-LDFLAGS		:= -liconv -lintl -lxml2 -lncurses -lz
+LDFLAGS		:= @LDFLAGS@ -liconv -lintl -lxml2 -lncurses -lz
 ifdef DEBUG
     CFLAGS	+= -O0 -ggdb3
     LDFLAGS	+= -g -rdynamic

--- a/configure
+++ b/configure
@@ -34,6 +34,7 @@ seds=[s/^#undef \(USE_UNSUPPORTED_AND_BROKEN_CODE\)/#define \1/]
 
 # First pair is used if nothing matches
 PROGS="CC=gcc CC=clang INSTALL=install MSGFMT=msgfmt"
+ENVIRONS="CFLAGS LDFLAGS"
 
 # Libs found using pkg-config
 LIBS="libxml-2.0 ncurses zlib"
@@ -194,10 +195,7 @@ done
 # And, finally, the environment variables
 for i in $ENVIRONS; do
     esciv="`eval echo '"'\$\{$i\}'"'|sed 's/\//\\\&/g'`"
-    ppath=`eval echo \$\{$pname\}`
-    ppath=`escpath "$ppath"`
-    [ ! -z "$ppath" ] && ppath=" $ppath"
-    sub "s/ @$i@/$ppath/g"
+    sub "s/@$i@/$esciv/g"
 done
 
 sub "$CUSTSUBS"


### PR DESCRIPTION
It looks like the configure script was intended to have support for this via the ENVIRONS variable, but that variable was never set. After setting it, I found that the code for processing it didn't make sense, as if it was unfinished with bits copied from elsewhere without being properly adapting. (For example, esciv was set but never used, and the $pname variable being referenced is from the previous PROGS loop and has nothing to do with environs.) I'm not sure if my changes match how this feature was intended to be implemented, but it seems to work for me.