### PR TITLE
Fix configure shellcheck errors

### DIFF
--- a/configure
+++ b/configure
@@ -42,11 +42,11 @@ pkg_ldflags=""
 
 # Automatic vars
 if [ -d .git ]; then
-    pkg_vverstr=`git describe --tags --always`
+    pkg_vverstr=$(git describe --tags --always)
     [ -z "$pkg_vverstr" ] || pkg_verstr=$pkg_vverstr
 fi
-pkg_major=`expr "$pkg_verstr" : 'v*\([0-9]*\)'`
-pkg_minor=`expr "$pkg_verstr" : 'v*[0-9]*\.\([0-9]*\)'`
+pkg_major=$(expr "$pkg_verstr" : 'v*\([0-9]*\)')
+pkg_minor=$(expr "$pkg_verstr" : 'v*[0-9]*\.\([0-9]*\)')
 pkg_string="$pkg_name $pkg_verstr"
 
 # Miscellaneous substitutions
@@ -54,7 +54,7 @@ custsubs="s/@pkg_name@/$pkg_name/g
 s/@pkg_version@/0x$pkg_major$pkg_minor/g
 s/@pkg_verstr@/$pkg_verstr/g
 s/@pkg_string@/$pkg_string/g
-s/@pkg_uname@/`echo $pkg_name|tr a-z A-Z`/g
+s/@pkg_uname@/$(echo $pkg_name|tr a-z A-Z)/g
 s/@pkg_bugreport@/$pkg_bugreport/g
 s/@pkg_major@/$pkg_major/g
 s/@pkg_minor@/$pkg_minor/g"
@@ -69,7 +69,7 @@ escpath() { echo $* | sed 's/\//\\\//g'; }
 
 #### Set host-dependent options ######################################
 
-SYSNAME=`uname|tr A-Z a-z`
+SYSNAME=$(uname|tr A-Z a-z)
 case "$SYSNAME" in
     *solaris*| *sun*)	SYSNAME="sun";;
     *darwin*| *osx*)	SYSNAME="mac";;
@@ -91,10 +91,10 @@ print_components() {
     cc=$components
     echo "Options:"
     while [ ! -z "$cc" ]; do
-	name=`expr "$cc" : '[^}]*name=\[\([^]]*\)\]'`
-	desc=`expr "$cc" : '[^}]*desc=\[\([^]]*\)\]'`
-	echo "  --$name	$desc"
-	cc=`expr "$cc" : '[^}]*}\(.*\)'`
+       name=$(expr "$cc" : '[^}]*name=\[\([^]]*\)\]')
+       desc=$(expr "$cc" : '[^}]*desc=\[\([^]]*\)\]')
+       echo "  --$name	$desc"
+       cc=$(expr "$cc" : '[^}]*}\(.*\)')
     done
     echo
 }
@@ -125,7 +125,7 @@ print_version() {
 
 sub_var() {
     local esc2
-    esc2=`escpath $2`
+    esc2=$(escpath $2)
     eval ac_var_$1='$esc2';
     sub "s/@$1@/$esc2/g"
 }
@@ -134,10 +134,10 @@ sub_comp() {
     local cc name seds
     cc=$components
     while [ ! -z "$cc" ]; do
-	name=`expr "$cc" : '[^}]*name=\[\([^]]*\)\]'`
-	seds=`expr "$cc" : '[^}]*seds=\[\([^]]*\)\]'`
-	[ "$name" = "$1" ] && sub "$seds"
-	cc=`expr "$cc" : '[^}]*}\(.*\)'`
+       name=$(expr "$cc" : '[^}]*name=\[\([^]]*\)\]')
+       seds=$(expr "$cc" : '[^}]*seds=\[\([^]]*\)\]')
+       [ "$name" = "$1" ] && sub "$seds"
+       cc=$(expr "$cc" : '[^}]*}\(.*\)')
     done
 }
 
@@ -146,8 +146,8 @@ for i in $*; do
 	--)		break;;
 	--version |-V)	print_version && die;;
 	--help |-h |-?)	print_help && die;;
-	--*=*)		sub_var `expr "$i" : '--\([^=]*\)='` `expr "$i" : '[^=]*=\(.*\)'`;;
-	--*)		sub_comp `expr "$i" : '--\(.*\)'`;;
+	--*=*)		sub_var $(expr "$i" : '--\([^=]*\)=') $(expr "$i" : '[^=]*=\(.*\)');;
+	--*)		sub_comp $(expr "$i" : '--\(.*\)');;
 	*)		echo "Error: unrecognized option \"$i\"" && die;;
     esac
 done
@@ -168,29 +168,29 @@ s/@builddir@/\$\{TMPDIR\}\/make/g"
 
 # Programs found using which
 for i in $progs; do
-    pname=`expr "$i" : '\([^=]*\)=[^=]*'`
-    pcall=`expr "$i" : '[^=]*=\([^=]*\)'`
-    ppath=`eval echo \$\{$pname\}`
-    ppath=`escpath "$ppath"`
+    pname=$(expr "$i" : '\([^=]*\)=[^=]*')
+    pcall=$(expr "$i" : '[^=]*=\([^=]*\)')
+    ppath=$(eval echo \$\{$pname\})
+    ppath=$(escpath "$ppath")
     # First check if an environment variable is set
     [ ! -z "$ppath" ] && sub "s/@$pname@/$ppath/g"
     # Check if the program exists
-    ppath=`which $pcall 2>/dev/null`
+    ppath=$(which $pcall 2>/dev/null)
     [ ! -z "$ppath" -a -x "$ppath" ] && sub "s/@$pname@/$pcall/g"
 done
 # If nothing found in first loop, set the first pair anyway
 for i in $progs; do
-    pname=`expr "$i" : '\([^=]*\)=[^=]*'`
-    pcall=`expr "$i" : '[^=]*=\([^=]*\)'`
+    pname=$(expr "$i" : '\([^=]*\)=[^=]*')
+    pcall=$(expr "$i" : '[^=]*=\([^=]*\)')
     sub "s/@$pname@/$pcall/g"
 done
 
 # Packages found using pkg-config
-pkgconfig=`which pkg-config 2>/dev/null`
+pkgconfig=$(which pkg-config 2>/dev/null)
 if [ ! -z "$pkgconfig" -a -x "$pkgconfig" ]; then
     faildeps=""
     for i in $pkgs; do
-	`$pkgconfig --exists $i` || faildeps="$i $faildeps"
+        $pkgconfig --exists $i || faildeps="$i $faildeps"
     done
     if [ ! -z "$faildeps" ]; then
 	echo "Error: missing required packages: $faildeps"; die
@@ -214,7 +214,7 @@ done
 touch config.status
 echo "#!/bin/sh
 $0 $*
-`tail -n+3 config.status`" > config.status.new
+$(tail -n+3 config.status)" > config.status.new
 chmod u+x config.status.new
 mv config.status.new config.status
 

--- a/configure
+++ b/configure
@@ -89,6 +89,7 @@ fi
 #### Printing helper functions #######################################
 
 print_components() {
+    # shellcheck disable=SC3043
     local cc name desc
     cc=$components
     echo "Options:"
@@ -126,6 +127,7 @@ print_version() {
 }
 
 sub_var() {
+    # shellcheck disable=SC3043
     local esc2
     esc2=$(escpath "$2")
     eval ac_var_"$1"='$esc2';
@@ -133,6 +135,7 @@ sub_var() {
 }
 
 sub_comp() {
+    # shellcheck disable=SC3043
     local cc name seds
     cc=$components
     while [ -n "$cc" ]; do

--- a/configure
+++ b/configure
@@ -65,7 +65,7 @@ s/@pkg_minor@/$pkg_minor/g"
 
 die() { rm -f config.sed; exit; }
 sub() { printf "%s\n" "$1">>config.sed; }
-escpath() { echo $* | sed 's/\//\\\//g'; }
+escpath() { echo "$@" | sed 's/\//\\\//g'; }
 
 #### Set host-dependent options ######################################
 
@@ -125,8 +125,8 @@ print_version() {
 
 sub_var() {
     local esc2
-    esc2=$(escpath $2)
-    eval ac_var_$1='$esc2';
+    esc2=$(escpath "$2")
+    eval ac_var_"$1"='$esc2';
     sub "s/@$1@/$esc2/g"
 }
 
@@ -141,13 +141,13 @@ sub_comp() {
     done
 }
 
-for i in $*; do
+for i in "$@"; do
     case $i in
 	--)		break;;
 	--version |-V)	print_version && die;;
 	--help |-h |-?)	print_help && die;;
-	--*=*)		sub_var $(expr "$i" : '--\([^=]*\)=') $(expr "$i" : '[^=]*=\(.*\)');;
-	--*)		sub_comp $(expr "$i" : '--\(.*\)');;
+	--*=*)		sub_var "$(expr "$i" : '--\([^=]*\)=')" "$(expr "$i" : '[^=]*=\(.*\)')";;
+	--*)		sub_comp "$(expr "$i" : '--\(.*\)')";;
 	*)		echo "Error: unrecognized option \"$i\"" && die;;
     esac
 done
@@ -161,7 +161,7 @@ s/@mandir@/${ac_var_mandir:=\$\{datadir\}\/man}/g
 s/@man1dir@/${ac_var_man1dir:=\$\{mandir\}\/man1}/g
 s/@localedir@/${ac_var_localedir:=\$\{datadir\}\/locale}/g
 s/@localepath@/${ac_var_prefix}\/share\/locale/g
-s/@TMPDIR@/$(escpath ${TMPDIR:-/tmp})/g
+s/@TMPDIR@/$(escpath "${TMPDIR:-/tmp}")/g
 s/@builddir@/\$\{TMPDIR\}\/make/g"
 
 #### Find programs and libs ##########################################
@@ -170,12 +170,12 @@ s/@builddir@/\$\{TMPDIR\}\/make/g"
 for i in $progs; do
     pname=$(expr "$i" : '\([^=]*\)=[^=]*')
     pcall=$(expr "$i" : '[^=]*=\([^=]*\)')
-    ppath=$(eval echo \$\{$pname\})
+    ppath=$(eval echo \$\{"$pname"\})
     ppath=$(escpath "$ppath")
     # First check if an environment variable is set
     [ ! -z "$ppath" ] && sub "s/@$pname@/$ppath/g"
     # Check if the program exists
-    ppath=$(which $pcall 2>/dev/null)
+    ppath=$(which "$pcall" 2>/dev/null)
     [ ! -z "$ppath" -a -x "$ppath" ] && sub "s/@$pname@/$pcall/g"
 done
 # If nothing found in first loop, set the first pair anyway
@@ -190,14 +190,14 @@ pkgconfig=$(which pkg-config 2>/dev/null)
 if [ ! -z "$pkgconfig" -a -x "$pkgconfig" ]; then
     faildeps=""
     for i in $pkgs; do
-        $pkgconfig --exists $i || faildeps="$i $faildeps"
+        $pkgconfig --exists "$i" || faildeps="$i $faildeps"
     done
     if [ ! -z "$faildeps" ]; then
 	echo "Error: missing required packages: $faildeps"; die
     fi
-    pkg_cflags=$(escpath "$($pkgconfig --cflags $pkgs)")
-    pkg_libs=$(escpath "$($pkgconfig --libs-only-l $pkgs)")
-    pkg_ldflags=$(escpath "$($pkgconfig --libs-only-L --libs-only-other $pkgs)")
+    pkg_cflags=$(escpath "$($pkgconfig --cflags "$pkgs")")
+    pkg_libs=$(escpath "$($pkgconfig --libs-only-l "$pkgs")")
+    pkg_ldflags=$(escpath "$($pkgconfig --libs-only-L --libs-only-other "$pkgs")")
 fi
 sub "s/@pkg_cflags@/$pkg_cflags/"
 sub "s/@pkg_libs@/$pkg_libs/"
@@ -208,7 +208,7 @@ sub "$custsubs"
 #### Apply substitutions to all files ################################
 
 for i in $files; do
-    sed -f config.sed $i.in > $i
+    sed -f config.sed "$i".in > "$i"
 done
 
 touch config.status

--- a/configure
+++ b/configure
@@ -92,7 +92,7 @@ print_components() {
     local cc name desc
     cc=$components
     echo "Options:"
-    while [ ! -z "$cc" ]; do
+    while [ -n "$cc" ]; do
        name=$(expr "$cc" : '[^}]*name=\[\([^]]*\)\]')
        desc=$(expr "$cc" : '[^}]*desc=\[\([^]]*\)\]')
        echo "  --$name	$desc"
@@ -135,7 +135,7 @@ sub_var() {
 sub_comp() {
     local cc name seds
     cc=$components
-    while [ ! -z "$cc" ]; do
+    while [ -n "$cc" ]; do
        name=$(expr "$cc" : '[^}]*name=\[\([^]]*\)\]')
        seds=$(expr "$cc" : '[^}]*seds=\[\([^]]*\)\]')
        [ "$name" = "$1" ] && sub "$seds"
@@ -175,10 +175,10 @@ for i in $progs; do
     ppath=$(eval echo \$\{"$pname"\})
     ppath=$(escpath "$ppath")
     # First check if an environment variable is set
-    [ ! -z "$ppath" ] && sub "s/@$pname@/$ppath/g"
+    [ -n "$ppath" ] && sub "s/@$pname@/$ppath/g"
     # Check if the program exists
     ppath=$(which "$pcall" 2>/dev/null)
-    [ ! -z "$ppath" -a -x "$ppath" ] && sub "s/@$pname@/$pcall/g"
+    [ -n "$ppath" ] && [ -x "$ppath" ] && sub "s/@$pname@/$pcall/g"
 done
 # If nothing found in first loop, set the first pair anyway
 for i in $progs; do
@@ -189,12 +189,12 @@ done
 
 # Packages found using pkg-config
 pkgconfig=$(which pkg-config 2>/dev/null)
-if [ ! -z "$pkgconfig" -a -x "$pkgconfig" ]; then
+if [ -n "$pkgconfig" ] && [ -x "$pkgconfig" ]; then
     faildeps=""
     for i in $pkgs; do
         $pkgconfig --exists "$i" || faildeps="$i $faildeps"
     done
-    if [ ! -z "$faildeps" ]; then
+    if [ -n "$faildeps" ]; then
 	echo "Error: missing required packages: $faildeps"; die
     fi
     pkg_cflags=$(escpath "$($pkgconfig --cflags "$pkgs")")

--- a/configure
+++ b/configure
@@ -146,8 +146,8 @@ for i in $*; do
 	--)		break;;
 	--version |-V)	print_version && die;;
 	--help |-h |-?)	print_help && die;;
-	--*=*)		sub_var `expr -- "$i" : '--\([^=]*\)='` `expr -- "$i" : '[^=]*=\(.*\)'`;;
-	--*)		sub_comp `expr -- "$i" : '--\(.*\)'`;;
+	--*=*)		sub_var `expr "$i" : '--\([^=]*\)='` `expr "$i" : '[^=]*=\(.*\)'`;;
+	--*)		sub_comp `expr "$i" : '--\(.*\)'`;;
 	*)		echo "Error: unrecognized option \"$i\"" && die;;
     esac
 done

--- a/configure
+++ b/configure
@@ -50,6 +50,7 @@ pkg_minor=$(expr "$pkg_verstr" : 'v*[0-9]*\.\([0-9]*\)')
 pkg_string="$pkg_name $pkg_verstr"
 
 # Miscellaneous substitutions
+# shellcheck disable=SC2018,SC2019
 custsubs="s/@pkg_name@/$pkg_name/g
 s/@pkg_version@/0x$pkg_major$pkg_minor/g
 s/@pkg_verstr@/$pkg_verstr/g
@@ -69,6 +70,7 @@ escpath() { echo "$@" | sed 's/\//\\\//g'; }
 
 #### Set host-dependent options ######################################
 
+# shellcheck disable=SC2018,SC2019
 SYSNAME=$(uname|tr A-Z a-z)
 case "$SYSNAME" in
     *solaris*| *sun*)	SYSNAME="sun";;


### PR DESCRIPTION
configure is defined by the shebang as a POSIX sh script, so shellcheck was used to fix several syntax errors.

In addition, a syntax error with `expr` which caused options given to configure to be missed was fixed.