### PR TITLE
Workaround ncurses bug for some libcs

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -39,6 +39,10 @@
 #ifndef _GNU_SOURCE
     #define _GNU_SOURCE 1
 #endif
+// Bug in ncurses when _GNU_SOURCE doesn't also set _XOPEN_SOURCE
+#ifndef _XOPEN_SOURCE
+    #define _XOPEN_SOURCE 700
+#endif
 // OS X needs this, otherwise socklen_t is not defined.
 #ifdef __APPLE__
     #define _BSD_SOCKLEN_T_


### PR DESCRIPTION
_GNU_SOURCE should enable the same functionality as _XOPEN_SOURCE,
but ncurses only enables widechar support if _XOPEN_SOURCE is set
(and greater than 500).

https://github.com/msharov/snownews/issues/59

This still works with builds of ncurses which don't support WIDECHAR, due to https://github.com/msharov/snownews/commit/448f9e20490dfdb9bde2f7c9928e72c89b203397. Even though we defin _XOPEN_SOURCE, if the local ncurses doesn't have the buggy `#ifdef`s which are present if it had WIDECHAR support, then `NCURSES_WIDECHAR` won't be set.